### PR TITLE
feat!: faster impl and node impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,35 +10,10 @@ npm install @chainsafe/is-ip
 
 ## Example
 
+Check if a string is an IP address
+
 ```typescript
 import { expect } from "chai";
-import {
-	parseIPv4,
-	parseIPv6,
-	parseIP,
-} from "@chainsafe/is-ip";
-
-// parse a string into IPv4 bytes
-const b1 = parseIPv4("127.0.0.1");
-expect(b1).to.deep.equal(Uint8Array.from([127, 0, 0, 1]));
-
-// parse a string into IPv6 bytes
-const b2 = parseIPv6("::1");
-expect(b2).to.deep.equal(Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]));
-
-// parse a string into either IPv4 or IPv6 bytes
-const b3 = parseIP("127.0.0.1");
-expect(b3).to.deep.equal(Uint8Array.from([127, 0, 0, 1]));
-
-const b4 = parseIP("::1");
-expect(b4).to.deep.equal(Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]));
-
-// parseIP* functions throw on invalid input
-try {
-	parseIP("not an IP");
-	expect.fail("not reached");
-} catch (e) {}
-
 import {
 	isIPv4,
 	isIPv6,
@@ -59,6 +34,35 @@ expect(isIP("127.0.0.1")).to.equal(true);
 expect(ipVersion("127.0.0.1")).to.equal(4);
 expect(ipVersion("1:2:3:4:5:6:7:8")).to.equal(6);
 expect(ipVersion("invalid ip")).to.equal(undefined);
+```
+
+Parse a string into IP address bytes
+
+```typescript
+import { expect } from "chai";
+import {
+	parseIPv4,
+	parseIPv6,
+	parseIP,
+} from "@chainsafe/is-ip/parse";
+
+// parse a string into IPv4 bytes
+const b1 = parseIPv4("127.0.0.1");
+expect(b1).to.deep.equal(Uint8Array.from([127, 0, 0, 1]));
+
+// parse a string into IPv6 bytes
+const b2 = parseIPv6("::1");
+expect(b2).to.deep.equal(Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]));
+
+// parse a string into either IPv4 or IPv6 bytes
+const b3 = parseIP("127.0.0.1");
+expect(b3).to.deep.equal(Uint8Array.from([127, 0, 0, 1]));
+
+const b4 = parseIP("::1");
+expect(b4).to.deep.equal(Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]));
+
+// parseIP* functions return undefined on invalid input
+expect(parseIP("not an IP")).to.equal(undefined);
 ```
 
 ## License

--- a/bench/comparison.test.ts
+++ b/bench/comparison.test.ts
@@ -1,5 +1,5 @@
 import { itBench } from "@dapplion/benchmark";
-import * as ours from "../src/index.js";
+import * as ours from "../src/is-ip.js";
 import * as net from "node:net";
 import * as isIpLib from "is-ip";
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/is-ip",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Check if a string is an IP address",
   "type": "module",
   "files": [
@@ -8,7 +8,11 @@
   ],
   "exports": {
     ".": {
-      "import": "./lib/index.js"
+      "node": "./lib/is-ip.node.js",
+      "import": "./lib/is-ip.js"
+    },
+    "./parse": {
+      "import": "./lib/parse.js"
     },
     "./parser": {
       "import": "./lib/parser.js"
@@ -23,7 +27,7 @@
       ]
     }
   },
-  "types": "./lib/index.d.ts",
+  "types": "./lib/is-ip.d.ts",
   "scripts": {
     "check-types": "tsc --noEmit",
     "bench": "ts-node-esm ./node_modules/.bin/benchmark bench/**/*.test.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,0 @@
-export * from "./is-ip.js";

--- a/src/is-ip.node.ts
+++ b/src/is-ip.node.ts
@@ -1,0 +1,8 @@
+import { isIPv4, isIPv6, isIP as ipVersion } from "node:net";
+
+export { isIPv4, isIPv6, ipVersion };
+
+/** Check if `input` is IPv4 or IPv6. */
+export function isIP(input: string): boolean {
+  return Boolean(ipVersion(input));
+}

--- a/src/is-ip.ts
+++ b/src/is-ip.ts
@@ -1,34 +1,4 @@
-import { Parser, err } from "./parser.js";
-
-// See https://stackoverflow.com/questions/166132/maximum-length-of-the-textual-representation-of-an-ipv6-address
-const MAX_IPV6_LENGTH = 45;
-const MAX_IPV4_LENGTH = 15;
-
-const parser = new Parser();
-
-/** Parse `input` into IPv4 bytes. */
-export function parseIPv4(input: string): Uint8Array {
-  if (input.length > MAX_IPV4_LENGTH) {
-    throw err;
-  }
-  return parser.new(input).parseWith(() => parser.readIPv4Addr());
-}
-
-/** Parse `input` into IPv6 bytes. */
-export function parseIPv6(input: string): Uint8Array {
-  if (input.length > MAX_IPV6_LENGTH) {
-    throw err;
-  }
-  return parser.new(input).parseWith(() => parser.readIPv6Addr());
-}
-
-/** Parse `input` into IPv4 or IPv6 bytes. */
-export function parseIP(input: string): Uint8Array {
-  if (input.length > MAX_IPV6_LENGTH) {
-    throw err;
-  }
-  return parser.new(input).parseWith(() => parser.readIPAddr());
-}
+import { parseIP, parseIPv4, parseIPv6 } from "./parse.js";
 
 /** Check if `input` is IPv4. */
 export function isIPv4(input: string): boolean {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,0 +1,31 @@
+import { Parser } from "./parser.js";
+
+// See https://stackoverflow.com/questions/166132/maximum-length-of-the-textual-representation-of-an-ipv6-address
+const MAX_IPV6_LENGTH = 45;
+const MAX_IPV4_LENGTH = 15;
+
+const parser = new Parser();
+
+/** Parse `input` into IPv4 bytes. */
+export function parseIPv4(input: string): Uint8Array | undefined {
+  if (input.length > MAX_IPV4_LENGTH) {
+    return undefined;
+  }
+  return parser.new(input).parseWith(() => parser.readIPv4Addr());
+}
+
+/** Parse `input` into IPv6 bytes. */
+export function parseIPv6(input: string): Uint8Array | undefined {
+  if (input.length > MAX_IPV6_LENGTH) {
+    return undefined;
+  }
+  return parser.new(input).parseWith(() => parser.readIPv6Addr());
+}
+
+/** Parse `input` into IPv4 or IPv6 bytes. */
+export function parseIP(input: string): Uint8Array | undefined {
+  if (input.length > MAX_IPV6_LENGTH) {
+    return undefined;
+  }
+  return parser.new(input).parseWith(() => parser.readIPAddr());
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { parseIPv4, parseIPv6 } from "../src/index.js";
+import { parseIPv4, parseIPv6 } from "../src/parse.js";
 
 describe("parseIPv4", () => {
   it("should return on valid IPv4 strings", () => {
@@ -25,11 +25,7 @@ describe("parseIPv4", () => {
         output: Uint8Array.from([255, 255, 255, 255]),
       },
     ]) {
-      try {
-        expect(parseIPv4(input)).to.deep.equal(output);
-      } catch (e) {
-        expect.fail(`${input}: ${(e as Error).message}`);
-      }
+      expect(parseIPv4(input)).to.deep.equal(output);
     }
   });
 
@@ -43,14 +39,7 @@ describe("parseIPv4", () => {
       "hahahahahaha",
       "1a.2.3.4",
     ]) {
-      try {
-        parseIPv4(input);
-        expect.fail(input);
-      } catch (e) {
-        if ((e as Error).message === input) {
-          throw e;
-        }
-      }
+      expect(parseIPv4(input)).to.equal(undefined);
     }
   });
 });
@@ -87,11 +76,7 @@ describe("parseIPv6", () => {
         output: Uint8Array.from([0x20, 1, 0x0d, 0xc5, 0x72, 0xa3, 0, 0, 0, 0, 0x80, 0x2e, 0x33, 0x70, 0x73, 0xe4]),
       },
     ]) {
-      try {
-        expect(parseIPv6(input)).to.deep.equal(output);
-      } catch (e) {
-        expect.fail(`${input}: ${(e as Error).message}`);
-      }
+      expect(parseIPv6(input)).to.deep.equal(output);
     }
   });
 
@@ -104,15 +89,7 @@ describe("parseIPv6", () => {
       "2001:0dc5:72a3:0000::0000:802e:3370:73E4",
       "0000:0000:0000:0000:0000:0000:ffff:192.168.100.228",
     ]) {
-      try {
-        parseIPv6(input);
-        expect.fail(input);
-        // eslint-disable-next-line no-empty
-      } catch (e) {
-        if ((e as Error).message === input) {
-          throw e;
-        }
-      }
+      expect(parseIPv6(input)).to.equal(undefined);
     }
   });
 });


### PR DESCRIPTION
cc @achingbrain

Two things here:
- adds a node-specific export to use `net.isIP`
- speeds up parsing to within 2x of `net.isIP`

BREAKING CHANGE:
`parseIP*` functions now return `Uint8Array | undefined`
`parseIP*` functions are only exported as a subpath, `@chainsafe/is-ip/parse`