### PR TITLE
fix: support parsing IPv6 addresses with zone indexes in browsers

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -30,11 +30,23 @@ jobs:
         run: yarn run check-types
       - name: Unit tests
         run: yarn test
-  
+
+  tests-chrome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: lts/*
+      - run: yarn install
+      - run: yarn build
+      - name: Unit tests
+        run: npx xvfb-maybe yarn test:chrome
+
   maybe-release:
     name: release
     runs-on: ubuntu-latest
-    needs: tests
+    needs: [tests, tests-chrome]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: google-github-actions/release-please-action@v3
@@ -44,19 +56,19 @@ jobs:
           package-name: release-please-action
           bump-minor-pre-major: false
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
-      
+
       - uses: actions/checkout@v3
         if: ${{ steps.release.outputs.release_created }}
-        
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
-      
+
       - run: yarn install
         if: ${{ steps.release.outputs.release_created }}
-      
+
       - run: yarn build
         if: ${{ steps.release.outputs.release_created }}
 

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -16,10 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node: [16, 17, 18]
+        node: [16, 18]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node}}
       - run: yarn install
@@ -34,8 +34,8 @@ jobs:
   tests-chrome:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: lts/*
       - run: yarn install

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "build": "tsc -p tsconfig.build.json",
     "prepublishOnly": "yarn build",
     "lint": "eslint --color --ext .ts src/ test/ bench/",
-    "test": "mocha test/**/*.test.ts"
+    "test": "mocha test/**/*.test.ts",
+    "test:chrome": "playwright-test --runner mocha test/**/*.test.ts"
   },
   "pre-push": [
     "lint"
@@ -85,9 +86,9 @@
     "karma": "^4.3.0",
     "mocha": "^10.0.0",
     "nyc": "^14.1.1",
+    "playwright-test": "^12.1.1",
     "prettier": "^2.6.2",
     "ts-node": "^10.8.1",
     "typescript": "^4.7.3"
-  },
-  "dependencies": {}
+  }
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -16,6 +16,10 @@ export function parseIPv4(input: string): Uint8Array | undefined {
 
 /** Parse `input` into IPv6 bytes. */
 export function parseIPv6(input: string): Uint8Array | undefined {
+  // strip zone index if it is present
+  if (input.includes("%")) {
+    input = input.split("%")[0];
+  }
   if (input.length > MAX_IPV6_LENGTH) {
     return undefined;
   }
@@ -24,6 +28,10 @@ export function parseIPv6(input: string): Uint8Array | undefined {
 
 /** Parse `input` into IPv4 or IPv6 bytes. */
 export function parseIP(input: string): Uint8Array | undefined {
+  // strip zone index if it is present
+  if (input.includes("%")) {
+    input = input.split("%")[0];
+  }
   if (input.length > MAX_IPV6_LENGTH) {
     return undefined;
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -64,6 +64,11 @@ const validIPv6 = [
     input: "abcd:0:1:2:3:4:5:6",
     output: Uint8Array.from([0xab, 0xcd, 0, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6]),
   },
+  {
+    // IPv6 with a zone index - https://en.wikipedia.org/wiki/IPv6_address#Scoped_literal_IPv6_addresses_(with_zone_index)
+    input: "fe80::8cb1:25ff:fec5:28e3%llw0",
+    output: Uint8Array.from([0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0x8c, 0xb1, 0x25, 0xff, 0xfe, 0xc5, 0x28, 0xe3]),
+  },
 ];
 
 const invalidIPv6 = [


### PR DESCRIPTION
IPv6 addresses like `fe80::8cb1:25ff:fec5:28e3%llw0` are valid but contain a zone index.  This is parsed correctly by the `net` module on node but not by the browser polyfill here.

The fix here is just to strip the `%` character and anything that follows it from the input string.

Adds a test for this, and also adds support for running the tests in Chrome in dev and CI.

Fixes #9