### PR TITLE
fix: include src in module tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Check if a string is an IP address",
   "type": "module",
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
Without this the source maps fail to resolve the module source:

```
WARNING in ../../node_modules/@chainsafe/is-ip/lib/parser.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/alex/Documents/Workspaces/libp2p/js-libp2p-examples/node_modules/@chainsafe/is-ip/src/parser.ts' file: Error: ENOENT: no such file or directory, open '/Users/alex/Documents/Workspaces/libp2p/js-libp2p-examples/node_modules/@chainsafe/is-ip/src/parser.ts'
```